### PR TITLE
Bug fixes

### DIFF
--- a/pyzdde/ddeclient.py
+++ b/pyzdde/ddeclient.py
@@ -192,6 +192,10 @@ class CreateConversation(object):
         """Exceptional error is handled in zdde Init() method, so the exception
         must be re-raised"""
         global number_of_apps_communicating
+
+        if number_of_apps_communicating >= 2:
+            raise DDEError('Too many open communications')
+
         self.ddeServerName = appName
         try:
             self.ddec = DDEClient(self.ddeServerName, self.ddeClientName) # establish conversation

--- a/pyzdde/ddeclient.py
+++ b/pyzdde/ddeclient.py
@@ -301,6 +301,10 @@ class DDEClient(object):
             raise DDEError("Unable to register with DDEML (err=%s)" % hex(res))
 
         hszServName = DDE.CreateStringHandle(self._idInst, service, CP_WINUNICODE)
+
+        if hszServName is None:
+            raise DDEError("Unable to get proper String Handle for Server")
+
         hszTopic = DDE.CreateStringHandle(self._idInst, topic, CP_WINUNICODE)
         # Try to establish conversation with the Zemax server
         self._hConv = DDE.Connect(self._idInst, hszServName, hszTopic, PCONVCONTEXT())

--- a/pyzdde/zdde.py
+++ b/pyzdde/zdde.py
@@ -5074,26 +5074,39 @@ class PyZDDE(object):
         zGetField()
         """
         if n:
-            # TODO update to handle zemax bug where the return expxted by zGetWave is returned  for all instances of zgetfield
-            fd = _co.namedtuple('fieldData', ['xf', 'yf', 'wgt',
-                                              'vdx', 'vdy',
-                                              'vcx', 'vcy', 'van'])
             arg3 = 1.0 if arg3 is None else arg3 # default weight
             cmd = ("SetField,{:d},{:1.20g},{:1.20g},{:1.20g},{:1.20g},{:1.20g}"
                    ",{:1.20g},{:1.20g},{:1.20g}"
                    .format(n, arg1, arg2, arg3, vdx, vdy, vcx, vcy, van))
+
+            reply = self._sendDDEcommand(cmd)
+            rs = reply.split(',')
+
+            if len(rs) == 2:  # The behaviour with the Zemax bug
+                fieldData = self.zGetField(n)
+
+            else:  # the expected behaviour, which is also expected to return
+                fd = _co.namedtuple('fieldData', ['xf', 'yf', 'wgt',
+                                                  'vdx', 'vdy',
+                                                  'vcx', 'vcy', 'van'])
+
+                fieldData = fd._make([float(elem) for elem in rs])
+
         else:
-            fd = _co.namedtuple('fieldData', ['type', 'numFields',
-                                              'maxX', 'maxY', 'normMethod'])
-            arg3 = 0 if arg3 is None else arg3 # default normalization
+            arg3 = 0 if arg3 is None else arg3  # default normalization
             cmd = ("SetField,{:d},{:d},{:d},{:d}".format(0, arg1, arg2, arg3))
-        reply = self._sendDDEcommand(cmd)
-        rs = reply.split(',')
-        if n:
-            fieldData = fd._make([float(elem) for elem in rs])
-        else:
-            fieldData = fd._make([int(elem) if (i==0 or i==1 or i==4)
-                                 else float(elem) for i, elem in enumerate(rs)])
+            reply = self._sendDDEcommand(cmd)
+            rs = reply.split(',')
+
+            if len(rs) == 2:  # The behaviour with the Zemax bug
+                fieldData = self.zGetField(n)
+
+            else:  # the expected behaviour, which is also expected to return
+                fd = _co.namedtuple('fieldData', ['type', 'numFields',
+                                                  'maxX', 'maxY', 'normMethod'])
+                fieldData = fd._make([int(elem) if (i == 0 or i == 1 or i == 4)
+                                      else float(elem) for i, elem in enumerate(rs)])
+
         return fieldData
 
     def zSetFloat(self):

--- a/pyzdde/zdde.py
+++ b/pyzdde/zdde.py
@@ -5074,6 +5074,7 @@ class PyZDDE(object):
         zGetField()
         """
         if n:
+            # TODO update to handle zemax bug where the return expxted by zGetWave is returned  for all instances of zgetfield
             fd = _co.namedtuple('fieldData', ['xf', 'yf', 'wgt',
                                               'vdx', 'vdy',
                                               'vcx', 'vcy', 'van'])


### PR DESCRIPTION
Hi Indranil,

I've made some changes to the code, as I ran into some bugs. These changes include:

1): Fixed the possibility to create a connection to a random DDE server by a sequential use of ln = pyz.PyZDDE(); ln.zDDEInit(); ln.zDDEClose(). The random DDE server returned None on a DDE command, which crashed the code. I added two checks to circumvent this, one by assessing the validity of the server upon connection (the hszServName is None in this occurance) , and a second one that checks the number of live connections before assigning the DDE sever name.

2): In my current version of Zemax (18.4), the zSetField() function does not return the expected values (as expected by the zDDE code, which matches the returns as stated in the manual). Instead, it returns the values that you would expect from zSetWave()/zGetWave(). The main goal of the command, setting a field value, still works. To solve this issue, I rewrote the function to first assess the number of returned values, and, if this is 2 (with the bug) in stead of 8 (as expected), it calls zGetField() (which works fine). 

Could you evaluate these changes?

Regards,

Luc
