### PR TITLE
Functionalities

### DIFF
--- a/pyzdde/zdde.py
+++ b/pyzdde/zdde.py
@@ -616,7 +616,17 @@ class PyZDDE(object):
     def apr(self, val):
         self._apr = val
 
-    
+    @property
+    def connection(self):
+        """Checks status of connection
+
+        Returns
+        -------
+        status: bool
+            True = connection online
+            False = connection offline
+        """
+        return self._connection
 
     # ZEMAX <--> PyZDDE client connection methods
     #--------------------------------------------

--- a/pyzdde/zdde.py
+++ b/pyzdde/zdde.py
@@ -12161,17 +12161,20 @@ def _getDecodedLineFromFile(fileObj):
         with fenc as f:
             for line in f:
                 decodedLine = line.decode(unicode_type)
+                decodedLine = _zfu.checkDecimalSeparators(decodedLine)
                 yield decodedLine.rstrip()
     else: # ascii
         with fileObj as f:
             for line in f:
                 if _global_pyver3: # ascii and Python 3.x
+                    line = _zfu.checkDecimalSeparators(line)
                     yield line.rstrip()
                 else:      # ascii and Python 2.x
                     try:
                         decodedLine = line.decode('raw-unicode-escape')
                     except:
                         decodedLine = line.decode('ascii', 'replace')
+                    decodedLine = _zfu.checkDecimalSeparators(decodedLine)
                     yield decodedLine.rstrip()
 
 def _readLinesFromFile(fileObj):

--- a/pyzdde/zfileutils.py
+++ b/pyzdde/zfileutils.py
@@ -888,7 +888,7 @@ def randomGridSagFile(mu=0, sigma=1, semidia=1, nx=201, ny=201, unitflag=0,
 
 
 def checkDecimalSeparators(string):
-    """Replaces all comma decimals sperators into points in the input string.
+    """Replaces all comma decimals separators into points in the input string.
 
     Parameters
     ----------
@@ -900,5 +900,5 @@ def checkDecimalSeparators(string):
     string: str
         The new string with the replaced decimal separators
     """
-    return _re.sub(r'((?<=\d)|(?<=\A)|(?<=-)),(?=\d)', r'.', string)
+    return _re.sub(r'((?<=\d)|(?<=\A)|(?<=-)|(?<=\s)),(?=\d)', r'.', string)
 

--- a/pyzdde/zfileutils.py
+++ b/pyzdde/zfileutils.py
@@ -17,6 +17,7 @@ import ctypes as _ctypes
 from struct import unpack as _unpack
 from struct import pack as _pack
 import math as _math
+import re as _re
 
 import pyzdde.config as _config
 _global_pyver3 = _config._global_pyver3
@@ -884,3 +885,20 @@ def randomGridSagFile(mu=0, sigma=1, semidia=1, nx=201, ny=201, unitflag=0,
                               delx, dely, unitflag, xdec, ydec, 
                               fname, comment, fext)
     return z, gridsagfile
+
+
+def checkDecimalSeparators(string):
+    """Replaces all comma decimals sperators into points in the input string.
+
+    Parameters
+    ----------
+    string: str
+        The input string in which the separators are to be replaced
+
+    Returns
+    -------
+    string: str
+        The new string with the replaced decimal separators
+    """
+    return _re.sub(r'(?<=\d),(?=\d)', r'.', string)
+

--- a/pyzdde/zfileutils.py
+++ b/pyzdde/zfileutils.py
@@ -900,5 +900,5 @@ def checkDecimalSeparators(string):
     string: str
         The new string with the replaced decimal separators
     """
-    return _re.sub(r'(?<=\d),(?=\d)', r'.', string)
+    return _re.sub(r'((?<=\d)|(?<=\A)|(?<=-)),(?=\d)', r'.', string)
 


### PR DESCRIPTION
Hi Indranil,

I've added some functionalities to the zDDE library, which might be of interest. The functionalities include:

**1)** The addition of a property to check the current connection status

**2)** I ran into problems with some command that are based on writing the result to a text file and then reading the textfile (such as zGetZernike()). On some computers, the decimal separators in these files are commas in stead of points. This resulted in ValueErrors, for instance in
`meta.append(float(_re.search(r'\d{1,3}\.\d{4,8}', meta_line).group()))` 
in line 9790 of the zdde code. 

To circumvent this valueError, I added the function `checkDecimalSeparators(string)` to pyzdde/zfileutils.py and implemented it in the _getDecodedLineFromFile() function in pyzdde/zdde.py. 

The function uses the regular expression `'((?<=\d)|(?<=\A)|(?<=-)|(?<=\s))'` to search for commas in strings that represent decimal separators and replace them by points. 

It **will** do perform the following conversions:
`'0,0' --> '0.0'`
`',0'   --> '.0'`
`' ,0' --> ' .0'`
`'-,0' --> '-.0'`

It **will not** perform the following conversions:
`'1,' --> 1.`  

> This separator is not expected to be a decimal separator, but rather a word separator, e.g. in:
> A = 1, B= 2

`'a,1' --> a.1`
`'1,a'   -->1.a`
`'a,a' --> 'a.a'`
`'a,' --> 'a.'`
`',a' --> '.a`
`' ,a' --> ' .a`

I've updated the regex twice in additional commits, if necessary, it can be updated for different behavior.

**3)** I updated zGetZernike() to handle instances where the Zernikes cannot be traced. For now, I chose to return a namedTuple filled with np.NaN on these occurrences, where the tuple is filled with the maximum amount of Zernike coefficients that you can acquire (37 for fringe, 231 for standard and annular Zernikes), in order to circumvent loops from running into errors.

Kind regards,
  
Luc