### PR TITLE
zSetSurfaceData with coordinate breaks

### DIFF
--- a/pyzdde/zdde.py
+++ b/pyzdde/zdde.py
@@ -6066,7 +6066,7 @@ class PyZDDE(object):
                 cmd = cmd+','+str(value)
             else:
                 raise ValueError('Invalid input, expecting float type code')
-        if code > 70:
+        if code in (71, 72, 73, 74, 75, 76):
             if arg2 != None:
                 cmd = cmd+","+str(arg2)
             else:

--- a/pyzdde/zdde.py
+++ b/pyzdde/zdde.py
@@ -6065,7 +6065,7 @@ class PyZDDE(object):
             if not isinstance(value,str):
                 cmd = cmd+','+str(value)
             else:
-                raise ValueError('Invalid input, expecting float type code')
+                raise ValueError('Invalid input, expecting additional argument')
         if code in (71, 72, 73, 74, 75, 76):
             if arg2 != None:
                 cmd = cmd+","+str(arg2)


### PR DESCRIPTION
Hi Indranil,

I updated the `zSetSurfaceData()` function to be able to handle CoordinateBreak Surfaces. The current implementation is not able to set the parameters of these surfaces, as  these parameters are set by codes **80** and **81** without an additional argument, while the `zSetSurfaceData()` function expects such an argument for all codes above 70. 

Therefore, I [changed](https://github.com/indranilsinharoy/PyZDDE/commit/95d85a8a1f80c9ace525ab7b34bc39f02f3465d9) the if statement that checks if the code is above 70 to an if statement that checks if the code is one of the codes that requires a second argument. 

Furthermore, I [updated](https://github.com/indranilsinharoy/PyZDDE/commit/4dcd16e0b3bbe8b95d528e81dba732741570f372) the error handeling to be more descriptive, if an additional argument is required but not supplied.

Could you have a look at these changes?

Best,

Luc